### PR TITLE
Optimize Serialization and DataTable Editor

### DIFF
--- a/Editor/DataDriven/DataTableEditorUtils.cs
+++ b/Editor/DataDriven/DataTableEditorUtils.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+namespace Kurisu.Framework.DataDriven.Editor
+{
+    /// <summary>
+    /// Utility for editing DataTable in editor script
+    /// </summary>
+    public static class DataTableEditorUtils
+    {
+        public static DataTableUpdateDelegate OnDataTablePreUpdate;
+        public static DataTableUpdateDelegate OnDataTablePostUpdate;
+        public static void SetRowStruct<T>(DataTable dataTable) where T : class, IDataTableRow
+        {
+            Undo.RecordObject(dataTable, "Update DataTable Row Struct");
+            dataTable.SetRowStruct(typeof(T));
+            EditorUtility.SetDirty(dataTable);
+        }
+        public static string ExportJson(DataTable dataTable)
+        {
+            return JsonUtility.ToJson(dataTable);
+        }
+        public static void ImportJson(DataTable dataTable, string jsonData)
+        {
+            Undo.RecordObject(dataTable, "Overwrite DataTable from Json");
+            JsonUtility.FromJsonOverwrite(jsonData, dataTable);
+        }
+        public static bool ValidNewRowId(DataTable dataTable, string oldRowId, string newRowId, out string result)
+        {
+            if (dataTable.GetRowMap().ContainsKey(newRowId))
+            {
+                result = oldRowId;
+                return false;
+            }
+            result = newRowId;
+            return true;
+        }
+        public static string GetNewRowId(DataTable dataTable)
+        {
+            return dataTable.NewRowId();
+        }
+    }
+}

--- a/Editor/DataDriven/DataTableEditorUtils.cs.meta
+++ b/Editor/DataDriven/DataTableEditorUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e39c05c4addcf64dbd2295d29ab1f64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Serialization/SerializedObjectWrapperManager.cs
+++ b/Editor/Serialization/SerializedObjectWrapperManager.cs
@@ -23,7 +23,7 @@ namespace Kurisu.Framework.Serialization.Editor
         {
             if (type == null) return null;
 
-            var wrapper = GlobalObjectManager.GetObject(softObjectHandle) as SerializedObjectWrapper;
+            var wrapper = softObjectHandle.GetObject() as SerializedObjectWrapper;
             // Validate wrapped type
             if (!wrapper || wrapper.Value.GetType() != type)
             {
@@ -39,7 +39,7 @@ namespace Kurisu.Framework.Serialization.Editor
         }
         public static SerializedObjectWrapper GetWrapper(Type type, SoftObjectHandle softObjectHandle)
         {
-            var wrapper = GlobalObjectManager.GetObject(softObjectHandle) as SerializedObjectWrapper;
+            var wrapper = softObjectHandle.GetObject() as SerializedObjectWrapper;
             // Validate wrapped type
             if (wrapper && wrapper.Value.GetType() != type)
             {

--- a/Modules/Resource/Runtime/AssemblyInfo.cs
+++ b/Modules/Resource/Runtime/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Kurisu.Framework.Resource.Editor")]

--- a/Modules/Resource/Runtime/AssemblyInfo.cs.meta
+++ b/Modules/Resource/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 820494790c79a9a4bb3c3c62d7ac1f34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/Resource/Runtime/SoftAssetReference.cs
+++ b/Modules/Resource/Runtime/SoftAssetReference.cs
@@ -36,10 +36,11 @@ namespace Kurisu.Framework.Resource
         public string Address;
 #if UNITY_EDITOR
         [SerializeField]
-        internal T Object;
+        internal string Guid;
         [SerializeField]
         internal bool Locked;
 #endif
+
         /// <summary>
         /// Create asset reference from address
         /// </summary>
@@ -48,17 +49,13 @@ namespace Kurisu.Framework.Resource
         {
             Address = address;
 #if UNITY_EDITOR
-            Object = null;
+            Guid = string.Empty;
             Locked = false;
 #endif
         }
         public readonly T Load<FUnregister>(ref FUnregister unregister) where FUnregister : struct, IUnRegister
         {
 #if UNITY_EDITOR
-            if (Object)
-            {
-                return Object;
-            }
             ResourceSystem.SafeCheck<T>(Address);
 #endif
             return ResourceSystem.AsyncLoadAsset<T>(Address).AddTo(ref unregister).WaitForCompletion();
@@ -67,10 +64,6 @@ namespace Kurisu.Framework.Resource
         public readonly async UniTask<T> LoadAsync<TUnregister>(IUnRegister unregister)
         {
 #if UNITY_EDITOR
-            if (Object)
-            {
-                return Object;
-            }
             await ResourceSystem.SafeCheckAsync<T>(Address);
 #endif
             return await ResourceSystem.AsyncLoadAsset<T>(Address).AddTo(unregister);
@@ -84,6 +77,10 @@ namespace Kurisu.Framework.Resource
         {
             return Address;
         }
+        public readonly bool IsValid()
+        {
+            return !string.IsNullOrEmpty(Address);
+        }
     }
     /// <summary>
     /// A lightweight asset reference only use address as identifier
@@ -94,7 +91,7 @@ namespace Kurisu.Framework.Resource
         public string Address;
 #if UNITY_EDITOR
         [SerializeField]
-        internal Object Object;
+        internal string Guid;
         [SerializeField]
         internal bool Locked;
 #endif
@@ -106,17 +103,13 @@ namespace Kurisu.Framework.Resource
         {
             Address = address;
 #if UNITY_EDITOR
-            Object = null;
+            Guid = string.Empty;
             Locked = false;
 #endif
         }
         public readonly Object Load<FUnregister>(ref FUnregister unregister) where FUnregister : struct, IUnRegister
         {
 #if UNITY_EDITOR
-            if (Object)
-            {
-                return Object;
-            }
             ResourceSystem.SafeCheck<Object>(Address);
 #endif
             return ResourceSystem.AsyncLoadAsset<Object>(Address).AddTo(ref unregister).WaitForCompletion();
@@ -125,10 +118,6 @@ namespace Kurisu.Framework.Resource
         public readonly async UniTask<Object> LoadAsync<TUnregister>(IUnRegister unregister)
         {
 #if UNITY_EDITOR
-            if (Object)
-            {
-                return Object;
-            }
             await ResourceSystem.SafeCheckAsync<Object>(Address);
 #endif
             return await ResourceSystem.AsyncLoadAsset<Object>(Address).AddTo(unregister);
@@ -141,6 +130,10 @@ namespace Kurisu.Framework.Resource
         public override readonly string ToString()
         {
             return Address;
+        }
+        public readonly bool IsValid()
+        {
+            return !string.IsNullOrEmpty(Address);
         }
     }
 }

--- a/Runtime/Core/Serialization/GlobalObjectManager.cs
+++ b/Runtime/Core/Serialization/GlobalObjectManager.cs
@@ -3,7 +3,7 @@ using UObject = UnityEngine.Object;
 namespace Kurisu.Framework.Serialization
 {
     /// <summary>
-    /// Class for managing dynamically created <see cref="UObject"/> 
+    /// Class for managing dynamically load/created <see cref="UObject"/> 
     /// </summary>
     public static class GlobalObjectManager
     {

--- a/Runtime/Core/Serialization/SerializedObject.cs
+++ b/Runtime/Core/Serialization/SerializedObject.cs
@@ -76,7 +76,6 @@ namespace Kurisu.Framework.Serialization
             {
                 value = default;
             }
-            objectHandle = 0;
         }
     }
 }

--- a/Runtime/Core/Serialization/SoftObjectHandle.cs
+++ b/Runtime/Core/Serialization/SoftObjectHandle.cs
@@ -1,4 +1,5 @@
 using UnityEngine.Assertions;
+using UObject = UnityEngine.Object;
 namespace Kurisu.Framework.Serialization
 {
     public readonly struct SoftObjectHandle
@@ -14,7 +15,7 @@ namespace Kurisu.Framework.Serialization
         {
             return Handle != 0;
         }
-        public SoftObjectHandle(ulong handle)
+        internal SoftObjectHandle(ulong handle)
         {
             Handle = handle;
         }
@@ -43,6 +44,14 @@ namespace Kurisu.Framework.Serialization
         public override int GetHashCode()
         {
             return Handle.GetHashCode();
+        }
+        /// <summary>
+        /// Get object if has been loaded
+        /// </summary>
+        /// <returns></returns>
+        public UObject GetObject()
+        {
+            return GlobalObjectManager.GetObject(this);
         }
     }
 }

--- a/Runtime/GamePlay/DataDriven/DataTable.cs
+++ b/Runtime/GamePlay/DataDriven/DataTable.cs
@@ -96,12 +96,35 @@ namespace Kurisu.Framework.DataDriven
             return true;
         }
         /// <summary>
+        /// Update a data row from the table
+        /// </summary>
+        /// <param name="RowName"></param>
+        /// <param name="newRow"></param>
+        /// <returns></returns>
+        public bool UpdateRow(string RowName, IDataTableRow newRow)
+        {
+            var internalMap = GetInternalRowMap();
+            if (!internalMap.TryGetValue(RowName, out var row))
+            {
+                return false;
+            }
+            row.RowData = SerializedObject<IDataTableRow>.FromObject(newRow);
+            return true;
+        }
+        /// <summary>
         /// Remove data rows from the table
         /// </summary>
         /// <param name="rowIndexs"></param>
         public void RemoveRow(List<int> rowIndexs)
         {
             m_rows = m_rows.Where((x, id) => !rowIndexs.Contains(id)).ToArray();
+        }
+        /// <summary>
+        /// Remove all data rows from the table
+        /// </summary>
+        public void RemoveAllRows()
+        {
+            m_rows = new DataTableRow[0];
         }
         /// <summary>
         /// Get all data rows as map with RowId as key
@@ -111,15 +134,19 @@ namespace Kurisu.Framework.DataDriven
         {
             return m_rows.ToDictionary(x => x.RowId, x => x.RowData.GetObject());
         }
-        public string ExportJson()
-        {
-            return JsonUtility.ToJson(this);
-        }
-        public void ImportJson(string jsonData)
-        {
-            JsonUtility.FromJsonOverwrite(jsonData, this);
-        }
         #region Internal API
+        internal Dictionary<string, DataTableRow> GetInternalRowMap()
+        {
+            return m_rows.ToDictionary(x => x.RowId, x => x);
+        }
+        /// <summary>
+        /// Internal use only, since we should ensure incomming row type is valid
+        /// </summary>
+        /// <param name="rowStructType"></param>
+        internal void SetRowStruct(Type rowStructType)
+        {
+            m_rowType = SerializedType<IDataTableRow>.FromType(rowStructType);
+        }
         internal string NewRowId()
         {
             var map = GetRowMap();


### PR DESCRIPTION
- Serialize guid instead of object directly.
- Fix DataTable header order not match with row.
- Add Editor helper `DataTableEditorUtils.cs`.
- Add DataTable RowId validation.