### PR TITLE
Merge dev v1.6.1

### DIFF
--- a/Core/Editor/DataDriven/DataTableEditorUtils.cs
+++ b/Core/Editor/DataDriven/DataTableEditorUtils.cs
@@ -7,6 +7,7 @@ using Chris.Resource.Editor;
 using UnityEditor;
 using UnityEngine;
 using UObject = UnityEngine.Object;
+
 namespace Chris.DataDriven.Editor
 {
     /// <summary>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.kurisu.chris",
   "displayName": "Chris",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "unity": "2022.3",
   "description": "A Unity development framework designed for efficient, flexible and professional workflows.",
   "keywords": [


### PR DESCRIPTION
- Optimize dynamic type builder performance: optimize time complexity from O(n) to O(1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves editor-time performance by adding caching for dynamic type generation and serialized wrapper reflection, plus a version bump.
> 
> - `DynamicTypeBuilder`: replaces module type scans with a `ConcurrentDictionary` cache for generated types (stores by full and alternative keys for backward compatibility)
> - `SerializedObjectWrapperManager`: caches `MakeGenericType`, `GetField("m_Value")`, and field attributes to reduce reflection overhead; defers `CreateDefaultValue` until wrapper creation
> - Bumps package `version` to `1.6.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ba07a7a22e25e8c70b405bc837d3ad8a141f5f3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->